### PR TITLE
fix: 统一代码块样式与博客主题风格一致

### DIFF
--- a/theme/layout.ejs
+++ b/theme/layout.ejs
@@ -10,7 +10,7 @@
     <link rel="apple-touch-icon" sizes="180x180" href="./assets/img/favicons/apple-touch-icon.png">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Source+Serif+Pro:ital,wght@0,400;0,700;1,400&display=swap">
     <link rel="stylesheet" href="style.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/github.min.css">
+    <!-- highlight.js 主题由 style.css 统一管理，不再引入外部主题 -->
 </head>
 <body>
     <nav class="navbar">

--- a/theme/style.css
+++ b/theme/style.css
@@ -5,6 +5,7 @@
     --primary-color: #2563EB;
     --border-color: #E5E7EB;
     --code-bg: #F3F4F6;
+    --code-color: #1A202C;
     --content-width: 720px; /* 限制宽度以实现居中和易读性 */
 }
 
@@ -75,25 +76,136 @@ body {
     margin-bottom: 1.5rem;
 }
 
-/* 2. 修复代码高亮样式 */
+/* ====== 代码块样式 - 与博客主题统一 ====== */
+
+/* 行内代码 */
+code {
+    background: var(--code-bg);
+    color: var(--code-color);
+    padding: 0.2em 0.4em;
+    border-radius: 4px;
+    font-family: 'JetBrains Mono', 'Courier New', monospace;
+    font-size: 0.88em;
+}
+
+/* 代码块容器 */
 pre {
     background: var(--code-bg);
+    color: var(--code-color);
     padding: 1.5rem;
     border-radius: 8px;
-    overflow-x: auto; /* 防止长代码撑开页面 */
+    overflow-x: auto;
     margin: 2rem 0;
     font-family: 'JetBrains Mono', 'Courier New', monospace;
     font-size: 0.9rem;
     line-height: 1.5;
+    border: 1px solid var(--border-color);
 }
 
-/* Highlight.js 颜色补丁 (北欧风配色) */
-.hljs-keyword { color: #2563EB; font-weight: bold; }
-.hljs-string { color: #059669; }
-.hljs-comment { color: #94A3B8; font-style: italic; }
-.hljs-number { color: #D97706; }
-.hljs-title, .hljs-function { color: #7C3AED; }
-.hljs-attr { color: #9333EA; }
+/* pre 内的 code 不重复加背景和 padding */
+pre code {
+    background: transparent;
+    color: inherit;
+    padding: 0;
+    border-radius: 0;
+    font-size: inherit;
+}
+
+/* ====== Highlight.js 北欧风配色 (浅色主题) ====== */
+.hljs { color: var(--text-main); }
+
+.hljs-keyword,
+.hljs-selector-tag,
+.hljs-literal { color: #2563EB; font-weight: bold; }
+
+.hljs-string,
+.hljs-addition,
+.hljs-regexp,
+.hljs-attr { color: #059669; }
+
+.hljs-comment,
+.hljs-quote,
+.hljs-meta .hljs-meta-string,
+.hljs-doctag { color: #94A3B8; font-style: italic; }
+
+.hljs-number,
+.hljs-built_in,
+.hljs-type,
+.hljs-template-variable,
+.hljs-tag .hljs-attr { color: #D97706; }
+
+.hljs-title,
+.hljs-function,
+.hljs-title.class_,
+.hljs-section { color: #7C3AED; }
+
+.hljs-attr,
+.hljs-attribute,
+.hljs-variable { color: #9333EA; }
+
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-subst { color: #0891B2; }
+
+.hljs-deletion { color: #DC2626; background: rgba(220, 38, 38, 0.08); }
+
+.hljs-meta { color: #64748B; }
+
+.hljs-emphasis { font-style: italic; }
+.hljs-strong { font-weight: bold; }
+
+/* ====== 暗色模式代码块 ====== */
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg-color: #0F172A;
+        --text-main: #E2E8F0;
+        --text-muted: #94A3B8;
+        --primary-color: #60A5FA;
+        --border-color: #1E293B;
+        --code-bg: #1E293B;
+        --code-color: #E2E8F0;
+    }
+
+    pre {
+        border-color: #334155;
+    }
+
+    .hljs { color: #E2E8F0; }
+
+    .hljs-keyword,
+    .hljs-selector-tag,
+    .hljs-literal { color: #93C5FD; }
+
+    .hljs-string,
+    .hljs-addition,
+    .hljs-regexp,
+    .hljs-attr { color: #6EE7B7; }
+
+    .hljs-comment,
+    .hljs-quote { color: #64748B; }
+
+    .hljs-number,
+    .hljs-built_in,
+    .hljs-type,
+    .hljs-template-variable { color: #FCD34D; }
+
+    .hljs-title,
+    .hljs-function,
+    .hljs-title.class_,
+    .hljs-section { color: #C4B5FD; }
+
+    .hljs-attr,
+    .hljs-attribute,
+    .hljs-variable { color: #F0ABFC; }
+
+    .hljs-symbol,
+    .hljs-bullet,
+    .hljs-link,
+    .hljs-subst { color: #67E8F9; }
+
+    .hljs-deletion { color: #FCA5A5; background: rgba(239, 68, 68, 0.15); }
+}
 
 /* 紧凑型文章列表样式 */
 .post-list .post-item {


### PR DESCRIPTION
## 修复 #12

### 问题
代码块背景色与博客整体主题风格不一致。原因：
1. 外部引入了 highlight.js 的 github.min.css 主题，其自带的背景色与 style.css 中的 `--code-bg` 冲突
2. style.css 中只定义了部分 hljs 颜色，缺少完整覆盖
3. 行内代码 `code` 没有统一的基础样式
4. 不支持暗色模式

### 修改内容

**theme/layout.ejs**
- 移除外部 highlight.js github.min.css 引用

**theme/style.css**
- 新增 `--code-color` CSS 变量
- 统一行内 code 和代码块 pre 的背景色为 `--code-bg`
- 补全所有 highlight.js 语法高亮类的北欧风配色（keyword/string/comment/number/title/function/attr/symbol/deletion 等）
- 新增 `pre code` 规则避免嵌套 code 重复背景和 padding
- 代码块新增边框（`border: 1px solid var(--border-color)`）增强层次感
- 新增完整的 `prefers-color-scheme: dark` 暗色模式支持，包含暗色背景和对应的语法高亮配色

### 验证
- 构建成功，14 篇文章正常生成
- 代码块背景色 `rgb(243, 244, 246)` 与主题 `--code-bg` 一致
- 外部 highlight.js CSS 已移除（0 个外部引用）
- 行内代码背景与代码块统一