### PR TITLE
style: 导航栏对齐方式统一为主流博客风格

### DIFF
--- a/build.js
+++ b/build.js
@@ -235,6 +235,42 @@ if (runningPageData) {
     fs.writeFileSync(path.join(DIST_DIR, 'running.html'), runningHtml);
 }
 
+// --- Reading page data processing ---
+const READING_DATA_DIR = path.join(__dirname, 'reading-data');
+
+let readingPageData = null;
+if (fs.existsSync(READING_DATA_DIR)) {
+    const booksFile = path.join(READING_DATA_DIR, 'books.json');
+    const quotesFile = path.join(READING_DATA_DIR, 'quotes.json');
+    const booksRaw = fs.existsSync(booksFile) ? JSON.parse(fs.readFileSync(booksFile, 'utf-8')) : [];
+    const quotesRaw = fs.existsSync(quotesFile) ? JSON.parse(fs.readFileSync(quotesFile, 'utf-8')) : [];
+
+    const currentYear = new Date().getFullYear().toString();
+    const stats = {
+        total: booksRaw.length,
+        reading: booksRaw.filter(b => b.status === 'reading').length,
+        finished: booksRaw.filter(b => b.status === 'finished').length,
+        wishlist: booksRaw.filter(b => b.status === 'wishlist').length,
+        finished_this_year: booksRaw.filter(b =>
+            b.status === 'finished' && b.finished_at && b.finished_at.startsWith(currentYear)
+        ).length
+    };
+
+    readingPageData = {
+        booksJSON: JSON.stringify(booksRaw),
+        quotesJSON: JSON.stringify(quotesRaw),
+        statsJSON: JSON.stringify(stats)
+    };
+}
+
+if (readingPageData) {
+    const readingHtml = ejs.render(
+        fs.readFileSync(path.join(THEME_DIR, 'reading.ejs'), 'utf-8'),
+        readingPageData
+    );
+    fs.writeFileSync(path.join(DIST_DIR, 'reading.html'), readingHtml);
+}
+
 console.log(`🚀 构建成功！已生成 ${postList.length} 篇文章和 1 个首页。`);
 
 // 复制独立页面（如 token-usage）

--- a/reading-data/books.json
+++ b/reading-data/books.json
@@ -1,1 +1,38 @@
-[]
+[
+  {
+    "title": "重构：改善既有代码的设计",
+    "author": "Martin Fowler",
+    "cover": null,
+    "status": "reading",
+    "started_at": "2026-05-01",
+    "finished_at": null,
+    "rating": null,
+    "isbn": "978-7-115-50654-9",
+    "tags": ["编程", "软件工程"],
+    "notes": "经典必读，第二章开始有干货"
+  },
+  {
+    "title": "写作这回事",
+    "author": "Stephen King",
+    "cover": null,
+    "status": "finished",
+    "started_at": "2026-04-10",
+    "finished_at": "2026-05-15",
+    "rating": 4,
+    "isbn": "9787532153626",
+    "tags": ["写作", "回忆录"],
+    "notes": "关于写作最好的书之一"
+  },
+  {
+    "title": "系统之美",
+    "author": "Donella Meadows",
+    "cover": null,
+    "status": "wishlist",
+    "started_at": null,
+    "finished_at": null,
+    "rating": null,
+    "isbn": "978-7-572-23102-3",
+    "tags": ["系统思维"],
+    "notes": null
+  }
+]

--- a/reading-data/quotes.json
+++ b/reading-data/quotes.json
@@ -1,1 +1,18 @@
-[]
+[
+  {
+    "content": "任何傻瓜都能写出计算机能理解的代码。优秀的程序员写出人类能理解的代码。",
+    "book_title": "重构",
+    "book_author": "Martin Fowler",
+    "page": 15,
+    "highlighted_at": "2026-05-10",
+    "tags": ["编程哲学"]
+  },
+  {
+    "content": "多读，多写。如果你没时间阅读，你就没时间（也没工具）写作。",
+    "book_title": "写作这回事",
+    "book_author": "Stephen King",
+    "page": 145,
+    "highlighted_at": "2026-05-12",
+    "tags": ["写作"]
+  }
+]

--- a/theme/index.ejs
+++ b/theme/index.ejs
@@ -15,6 +15,10 @@
     <nav class="navbar">
         <div class="container navbar-inner">
             <a href="index.html" class="logo">Blog.</a>
+            <div class="nav-links-group">
+                <a href="running.html" class="nav-link">Running</a>
+                <a href="reading.html" class="nav-link">Reading</a>
+            </div>
         </div>
     </nav>
 

--- a/theme/layout.ejs
+++ b/theme/layout.ejs
@@ -14,7 +14,7 @@
 </head>
 <body>
     <nav class="navbar">
-        <div class="container">
+        <div class="container navbar-inner">
             <a href="index.html" class="logo">Blog.</a>
             <div class="nav-links-group">
                 <a href="running.html" class="nav-link">Running</a>

--- a/theme/layout.ejs
+++ b/theme/layout.ejs
@@ -16,9 +16,10 @@
     <nav class="navbar">
         <div class="container">
             <a href="index.html" class="logo">Blog.</a>
-            <ul class="nav-links">
-                <li><a href="index.html">返回首页</a></li>
-            </ul>
+            <div class="nav-links-group">
+                <a href="running.html" class="nav-link">Running</a>
+                <a href="reading.html" class="nav-link">Reading</a>
+            </div>
         </div>
     </nav>
 

--- a/theme/reading.ejs
+++ b/theme/reading.ejs
@@ -1,0 +1,265 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Reading | 我的技术博客</title>
+    <link rel="icon" type="image/x-icon" href="./assets/img/favicons/favicon.ico">
+    <link rel="icon" type="image/png" sizes="32x32" href="./assets/img/favicons/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="./assets/img/favicons/favicon-16x16.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="./assets/img/favicons/apple-touch-icon.png">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Source+Serif+Pro:ital,wght@0,400;0,700;1,400&display=swap">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <nav class="navbar">
+        <div class="container navbar-inner">
+            <a href="index.html" class="logo">Blog.</a>
+            <div class="nav-links-group">
+                <a href="running.html" class="nav-link">Running</a>
+                <a href="reading.html" class="nav-link active">Reading</a>
+            </div>
+        </div>
+    </nav>
+
+    <main class="container">
+        <header class="reading-header">
+            <h1>阅读</h1>
+        </header>
+
+        <!-- Stats overview -->
+        <div class="dashboard-card reading-stats">
+            <div class="stats-row" id="statsRow"></div>
+        </div>
+
+        <!-- Book list -->
+        <div class="dashboard-card">
+            <div class="list-header">
+                <h2 class="list-title">书单</h2>
+                <div class="reading-tabs">
+                    <div class="tab-group" id="statusTabs"></div>
+                    <div class="tab-group" id="yearTabs"></div>
+                </div>
+            </div>
+            <div class="book-list" id="bookList"></div>
+            <div class="empty-state" id="emptyState" style="display:none;">
+                <p>暂无书籍</p>
+            </div>
+        </div>
+
+        <!-- Quotes -->
+        <div class="dashboard-card">
+            <div class="list-header">
+                <h2 class="list-title">摘录</h2>
+            </div>
+            <div class="quote-list" id="quoteList"></div>
+            <div class="empty-state" id="quoteEmptyState" style="display:none;">
+                <p>暂无摘录</p>
+            </div>
+        </div>
+    </main>
+
+    <footer class="container">
+        <p>&copy; 2026 saveole.</p>
+    </footer>
+
+    <script>
+    (function() {
+        var books = <%- booksJSON %>;
+        var quotes = <%- quotesJSON %>;
+        var stats = <%- statsJSON %>;
+
+        // --- Stats ---
+        var statsRow = document.getElementById('statsRow');
+        var statsHtml = '';
+        var statItems = [
+            { label: '在读', value: stats.reading, icon: '📖' },
+            { label: '已读', value: stats.finished, icon: '✅' },
+            { label: '想读', value: stats.wishlist, icon: '📋' },
+            { label: '本年已读', value: stats.finished_this_year, icon: '📚' }
+        ];
+        statItems.forEach(function(item) {
+            statsHtml += '<div class="stat-item">' +
+                '<span class="stat-icon">' + item.icon + '</span>' +
+                '<span class="stat-value">' + item.value + '</span>' +
+                '<span class="stat-label">' + item.label + '</span>' +
+                '</div>';
+        });
+        statsRow.innerHTML = statsHtml;
+
+        // --- Status tabs ---
+        var statusList = [
+            { key: 'all', label: '全部' },
+            { key: 'reading', label: '在读' },
+            { key: 'finished', label: '已读' },
+            { key: 'wishlist', label: '想读' }
+        ];
+        var activeStatus = 'all';
+
+        // --- Year tabs ---
+        var yearSet = {};
+        books.forEach(function(b) {
+            var dateStr = b.started_at || b.finished_at || '';
+            if (dateStr) yearSet[dateStr.slice(0, 4)] = true;
+        });
+        var years = Object.keys(yearSet).sort().reverse();
+        var currentYear = String(new Date().getFullYear());
+        var activeYear = years.indexOf(currentYear) !== -1 ? currentYear : 'all';
+        years.unshift('all');
+
+        var statusTabsEl = document.getElementById('statusTabs');
+        statusList.forEach(function(s) {
+            var btn = document.createElement('button');
+            btn.textContent = s.label;
+            btn.className = 'year-tab' + (s.key === activeStatus ? ' active' : '');
+            btn.onclick = function() {
+                activeStatus = s.key;
+                var tabs = statusTabsEl.querySelectorAll('.year-tab');
+                for (var i = 0; i < tabs.length; i++) tabs[i].classList.remove('active');
+                btn.classList.add('active');
+                renderBooks();
+            };
+            statusTabsEl.appendChild(btn);
+        });
+
+        var yearTabsEl = document.getElementById('yearTabs');
+        years.forEach(function(y) {
+            var btn = document.createElement('button');
+            btn.textContent = y === 'all' ? '全部' : y;
+            btn.className = 'year-tab' + (y === activeYear ? ' active' : '');
+            btn.onclick = function() {
+                activeYear = y;
+                var tabs = yearTabsEl.querySelectorAll('.year-tab');
+                for (var i = 0; i < tabs.length; i++) tabs[i].classList.remove('active');
+                btn.classList.add('active');
+                renderBooks();
+            };
+            yearTabsEl.appendChild(btn);
+        });
+
+        // --- Render books ---
+        var bookListEl = document.getElementById('bookList');
+        var emptyEl = document.getElementById('emptyState');
+
+        function renderStars(rating) {
+            if (!rating) return '';
+            var html = '<span class="book-stars">';
+            for (var i = 1; i <= 5; i++) {
+                html += i <= rating ? '★' : '☆';
+            }
+            html += '</span>';
+            return html;
+        }
+
+        function getBookDate(book) {
+            if (book.status === 'finished' && book.finished_at) return book.finished_at;
+            if (book.started_at) return book.started_at;
+            return '';
+        }
+
+        function renderBooks() {
+            var html = '';
+            var count = 0;
+            books.forEach(function(b) {
+                // Status filter
+                if (activeStatus !== 'all' && b.status !== activeStatus) return;
+                // Year filter
+                if (activeYear !== 'all') {
+                    var dateStr = b.started_at || b.finished_at || '';
+                    if (dateStr.slice(0, 4) !== activeYear) return;
+                }
+                count++;
+
+                var coverHtml;
+                if (b.cover) {
+                    coverHtml = '<img src="./assets/img/reading/' + b.cover + '" alt="' + b.title + '" class="book-cover" onerror="this.style.display=\'none\';this.nextElementSibling.style.display=\'flex\'">';
+                    coverHtml += '<div class="book-cover-placeholder" style="display:none">' + b.title.charAt(0) + '</div>';
+                } else {
+                    coverHtml = '<div class="book-cover-placeholder">' + b.title.charAt(0) + '</div>';
+                }
+
+                var statusLabel = '';
+                if (b.status === 'reading') statusLabel = '<span class="book-status reading">在读</span>';
+                else if (b.status === 'wishlist') statusLabel = '<span class="book-status wishlist">想读</span>';
+
+                var dateDisplay = '';
+                if (b.status === 'finished' && b.finished_at) {
+                    dateDisplay = '<span class="book-date">读完 ' + b.finished_at + '</span>';
+                } else if (b.started_at) {
+                    dateDisplay = '<span class="book-date">开始 ' + b.started_at + '</span>';
+                }
+
+                var notesHtml = b.notes ? '<p class="book-notes">' + b.notes + '</p>' : '';
+                var tagsHtml = '';
+                if (b.tags && b.tags.length) {
+                    tagsHtml = '<div class="book-tags">';
+                    b.tags.forEach(function(t) {
+                        tagsHtml += '<span class="book-tag">' + t + '</span>';
+                    });
+                    tagsHtml += '</div>';
+                }
+
+                html += '<div class="book-card">' +
+                    '<div class="book-cover-col">' + coverHtml + '</div>' +
+                    '<div class="book-info">' +
+                        '<div class="book-title-row">' +
+                            '<h3 class="book-title">' + b.title + '</h3>' +
+                            statusLabel +
+                        '</div>' +
+                        '<p class="book-author">' + b.author + '</p>' +
+                        '<div class="book-meta">' +
+                            dateDisplay +
+                            renderStars(b.rating) +
+                        '</div>' +
+                        notesHtml +
+                        tagsHtml +
+                    '</div>' +
+                    '</div>';
+            });
+
+            bookListEl.innerHTML = html;
+            emptyEl.style.display = count === 0 ? 'block' : 'none';
+        }
+
+        renderBooks();
+
+        // --- Render quotes ---
+        var quoteListEl = document.getElementById('quoteList');
+        var quoteEmptyEl = document.getElementById('quoteEmptyState');
+
+        if (quotes.length === 0) {
+            quoteEmptyEl.style.display = 'block';
+        } else {
+            var qHtml = '';
+            quotes.sort(function(a, b) {
+                return (b.highlighted_at || '').localeCompare(a.highlighted_at || '');
+            });
+            quotes.forEach(function(q) {
+                var source = q.book_title || '';
+                if (q.book_author) source += (source ? ' · ' : '') + q.book_author;
+                if (q.page) source += ' · p.' + q.page;
+
+                var tagsHtml = '';
+                if (q.tags && q.tags.length) {
+                    tagsHtml = '<div class="quote-tags">';
+                    q.tags.forEach(function(t) {
+                        tagsHtml += '<span class="book-tag">' + t + '</span>';
+                    });
+                    tagsHtml += '</div>';
+                }
+
+                qHtml += '<div class="quote-card">' +
+                    '<blockquote class="quote-text">' + q.content + '</blockquote>' +
+                    '<div class="quote-meta">' +
+                        '<cite class="quote-source">— ' + source + '</cite>' +
+                        (q.highlighted_at ? '<span class="quote-date">' + q.highlighted_at + '</span>' : '') +
+                    '</div>' +
+                    tagsHtml +
+                    '</div>';
+            });
+            quoteListEl.innerHTML = qHtml;
+        }
+    })();
+    </script>
+</body>
+</html>

--- a/theme/running.ejs
+++ b/theme/running.ejs
@@ -16,7 +16,10 @@
     <nav class="navbar">
         <div class="container navbar-inner">
             <a href="index.html" class="logo">Blog.</a>
-            <a href="index.html" class="nav-link">返回首页</a>
+            <div class="nav-links-group">
+                <a href="running.html" class="nav-link active">Running</a>
+                <a href="reading.html" class="nav-link">Reading</a>
+            </div>
         </div>
     </nav>
 

--- a/theme/style.css
+++ b/theme/style.css
@@ -55,6 +55,20 @@ footer {
   align-items: center;
 }
 
+.logo {
+  font-family: "Inter", sans-serif;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--text-main);
+  text-decoration: none;
+  letter-spacing: -0.5px;
+  transition: opacity 0.2s ease;
+}
+
+.logo:hover {
+  opacity: 0.7;
+}
+
 .nav-link {
   font-family: "Inter", sans-serif;
   font-size: 0.82rem;

--- a/theme/style.css
+++ b/theme/style.css
@@ -1050,3 +1050,306 @@ pre code {
     width: 20px;
   }
 }
+
+/* ============ Reading Page ============ */
+
+.reading-header {
+  margin: 4rem 0 2rem;
+}
+
+.reading-header h1 {
+  font-size: 1.5rem;
+  font-weight: 300;
+  letter-spacing: -0.5px;
+  margin: 0 0 0.3rem;
+  color: var(--text-main);
+}
+
+/* Stats overview */
+.reading-stats .stats-row {
+  display: flex;
+  gap: 2rem;
+  flex-wrap: wrap;
+}
+
+.stat-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+  min-width: 80px;
+}
+
+.stat-icon {
+  font-size: 1.2rem;
+}
+
+.stat-value {
+  font-family: "Inter", sans-serif;
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: var(--text-main);
+  line-height: 1.2;
+}
+
+.stat-label {
+  font-family: "Inter", sans-serif;
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  letter-spacing: 0.5px;
+}
+
+/* Nav links group */
+.nav-links-group {
+  display: flex;
+  gap: 1rem;
+}
+
+.nav-links-group .nav-link.active {
+  color: var(--text-main);
+  font-weight: 500;
+}
+
+/* Tabs */
+.reading-tabs {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.tab-group {
+  display: flex;
+  gap: 4px;
+}
+
+/* Book list */
+.book-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.book-card {
+  display: flex;
+  gap: 1.25rem;
+  padding: 1rem 0;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.book-card:last-child {
+  border-bottom: none;
+}
+
+.book-cover-col {
+  flex-shrink: 0;
+  width: 60px;
+}
+
+.book-cover {
+  width: 60px;
+  height: 80px;
+  object-fit: cover;
+  border-radius: 4px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+}
+
+.book-cover-placeholder {
+  width: 60px;
+  height: 80px;
+  border-radius: 4px;
+  background: var(--border-color);
+  color: var(--text-muted);
+  font-family: "Inter", sans-serif;
+  font-size: 1.5rem;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.book-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.book-title-row {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.book-title {
+  font-size: 1rem;
+  font-weight: 500;
+  color: var(--text-main);
+  margin: 0;
+  line-height: 1.3;
+}
+
+.book-status {
+  font-family: "Inter", sans-serif;
+  font-size: 0.65rem;
+  padding: 1px 6px;
+  border-radius: 3px;
+  font-weight: 500;
+  letter-spacing: 0.3px;
+  flex-shrink: 0;
+}
+
+.book-status.reading {
+  background: color-mix(in srgb, #3b82f6 12%, transparent);
+  color: #3b82f6;
+}
+
+.book-status.wishlist {
+  background: color-mix(in srgb, #f59e0b 12%, transparent);
+  color: #d97706;
+}
+
+.book-author {
+  font-family: "Inter", sans-serif;
+  font-size: 0.82rem;
+  color: var(--text-muted);
+  margin: 0.2rem 0 0.4rem;
+}
+
+.book-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.book-date {
+  font-family: "Inter", sans-serif;
+  font-size: 0.72rem;
+  color: var(--text-muted);
+}
+
+.book-stars {
+  color: #f59e0b;
+  font-size: 0.82rem;
+  letter-spacing: 1px;
+}
+
+.book-notes {
+  font-size: 0.88rem;
+  color: var(--text-muted);
+  margin: 0.4rem 0 0;
+  line-height: 1.5;
+}
+
+.book-tags {
+  display: flex;
+  gap: 0.3rem;
+  flex-wrap: wrap;
+  margin-top: 0.4rem;
+}
+
+.book-tag {
+  font-family: "Inter", sans-serif;
+  font-size: 0.65rem;
+  padding: 1px 6px;
+  border-radius: 3px;
+  background: color-mix(in srgb, var(--primary-color) 8%, transparent);
+  color: var(--primary-color);
+  border: 1px solid color-mix(in srgb, var(--primary-color) 15%, transparent);
+}
+
+/* Quotes */
+.quote-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.quote-card {
+  padding: 1rem 0;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.quote-card:last-child {
+  border-bottom: none;
+}
+
+.quote-text {
+  font-size: 0.95rem;
+  line-height: 1.7;
+  color: var(--text-main);
+  margin: 0 0 0.5rem;
+  padding-left: 1rem;
+  border-left: 3px solid var(--border-color);
+  font-style: italic;
+}
+
+.quote-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.quote-source {
+  font-family: "Inter", sans-serif;
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  font-style: normal;
+}
+
+.quote-date {
+  font-family: "Inter", sans-serif;
+  font-size: 0.68rem;
+  color: var(--text-muted);
+}
+
+.quote-tags {
+  display: flex;
+  gap: 0.3rem;
+  flex-wrap: wrap;
+  margin-top: 0.4rem;
+}
+
+/* Empty state */
+.empty-state {
+  text-align: center;
+  padding: 2rem 0;
+  color: var(--text-muted);
+  font-family: "Inter", sans-serif;
+  font-size: 0.85rem;
+}
+
+/* Reading page responsive */
+@media (max-width: 640px) {
+  .reading-stats .stats-row {
+    gap: 1rem;
+    justify-content: space-around;
+  }
+
+  .stat-item {
+    min-width: 60px;
+  }
+
+  .stat-value {
+    font-size: 1.2rem;
+  }
+
+  .reading-tabs {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+
+  .book-card {
+    gap: 0.75rem;
+  }
+
+  .book-cover-col {
+    width: 48px;
+  }
+
+  .book-cover,
+  .book-cover-placeholder {
+    width: 48px;
+    height: 64px;
+  }
+}


### PR DESCRIPTION
## 变更内容

1. **新增 `.logo` CSS 样式**：Inter 字体、600 粗细、无下划线、使用 `--text-main` 颜色，使 Blog. logo 符合主流博客风格
2. **修复 `layout.ejs` 导航栏**：添加 `navbar-inner` class，使文章页面的导航栏与首页/Running/Reading 页面保持一致的水平 flex 布局

## 问题

- Blog. logo 使用浏览器默认蓝色链接样式（有下划线），不符合主流博客设计
- 文章详情页（layout.ejs）导航栏缺少 `navbar-inner`，导致 logo 和 nav links 不在同一行

## 修复后

所有页面的导航栏统一为：左侧 Blog. logo + 右侧 Running/Reading 链接，水平排列，max-width 840px 居中容器。