### PR TITLE
feat: Running 模块添加跑步轨迹图

### DIFF
--- a/build.js
+++ b/build.js
@@ -223,10 +223,24 @@ if (fs.existsSync(RUNNING_DATA_DIR)) {
         cadence_spm: a.cadence_spm
     })).sort((a, b) => b.date.localeCompare(a.date));
 
+    // Build tracks data: activities with polyline, sorted by date desc
+    const tracks = activitiesRaw
+        .filter(a => a.summary_polyline)
+        .map(a => ({
+            date: a.date,
+            distance_km: a.distance_km,
+            pace: formatPace(a.avg_pace_s_per_km),
+            duration: formatDuration(a.duration_s),
+            summary_polyline: a.summary_polyline
+        }))
+        .sort((a, b) => b.date.localeCompare(a.date))
+        .slice(0, 12);
+
     runningPageData = {
         timelineJSON: JSON.stringify(timeline),
         bodyJSON: JSON.stringify(bodyRaw),
-        activitiesJSON: JSON.stringify(activities)
+        activitiesJSON: JSON.stringify(activities),
+        tracksJSON: JSON.stringify(tracks)
     };
 }
 

--- a/scripts/sync_garmin.py
+++ b/scripts/sync_garmin.py
@@ -106,6 +106,7 @@ def main():
         max_hr = act.get("maxHR") or 0
         cadence = act.get("averageRunningCadenceInStepsPerMinute") or 0
         vo2max = act.get("vO2MaxValue") or 0
+        summary_polyline = act.get("summaryPolyline", "")
 
         if date not in day_map:
             day_map[date] = {
@@ -119,6 +120,7 @@ def main():
                 "max_hr": 0,
                 "cadence_spm": 0.0,
                 "vo2max": 0.0,
+                "summary_polyline": "",
                 "_hr_weight": 0.0,
                 "_cadence_weight": 0.0,
             }
@@ -141,6 +143,10 @@ def main():
             w = d["_cadence_weight"] + dist_km
             d["cadence_spm"] = (d["cadence_spm"] * d["_cadence_weight"] + cadence * dist_km) / w
             d["_cadence_weight"] = w
+
+        # Keep polyline from outdoor runs (prefer non-empty)
+        if summary_polyline:
+            d["summary_polyline"] = summary_polyline
 
     # Finalize: calculate pace from totals, round values, remove helper fields
     for d in day_map.values():

--- a/theme/running.ejs
+++ b/theme/running.ejs
@@ -25,10 +25,16 @@
 
     <main class="container">
         <header class="running-header">
-            <h1>跑步和体重趋势</h1>
+            <div class="running-header-row">
+                <h1>跑步和体重趋势</h1>
+                <div class="chart-tabs" id="chartTabs">
+                    <button class="chart-tab active" data-tab="charts">图表</button>
+                    <button class="chart-tab" data-tab="tracks">轨迹</button>
+                </div>
+            </div>
         </header>
 
-        <div class="dashboard-card">
+        <div class="dashboard-card" id="chartsPanel">
             <div class="chart-row">
                 <canvas id="bodyChart"></canvas>
             </div>
@@ -36,6 +42,10 @@
             <div class="chart-row">
                 <canvas id="runningChart"></canvas>
             </div>
+        </div>
+
+        <div class="dashboard-card" id="tracksPanel" style="display:none;">
+            <div class="tracks-grid" id="tracksGrid"></div>
         </div>
 
         <div class="dashboard-card">
@@ -70,6 +80,98 @@
         var timeline = <%- timelineJSON %>;
         var bodyRecords = <%- bodyJSON %>;
         var activityRecords = <%- activitiesJSON %>;
+        var trackRecords = <%- tracksJSON %>;
+
+        // ---- Chart/Tracks tab switching ----
+        (function() {
+            var tabs = document.querySelectorAll('.chart-tab');
+            var chartsPanel = document.getElementById('chartsPanel');
+            var tracksPanel = document.getElementById('tracksPanel');
+            tabs.forEach(function(tab) {
+                tab.addEventListener('click', function() {
+                    tabs.forEach(function(t) { t.classList.remove('active'); });
+                    tab.classList.add('active');
+                    if (tab.dataset.tab === 'charts') {
+                        chartsPanel.style.display = '';
+                        tracksPanel.style.display = 'none';
+                    } else {
+                        chartsPanel.style.display = 'none';
+                        tracksPanel.style.display = '';
+                        renderTracks();
+                    }
+                });
+            });
+        })();
+
+        // ---- Polyline decoder (Google encoded polyline) ----
+        function decodePolyline(encoded) {
+            var points = [];
+            var index = 0, lat = 0, lng = 0;
+            while (index < encoded.length) {
+                var b, shift = 0, result = 0;
+                do {
+                    b = encoded.charCodeAt(index++) - 63;
+                    result |= (b & 0x1f) << shift;
+                    shift += 5;
+                } while (b >= 0x20);
+                lat += ((result & 1) ? ~(result >> 1) : (result >> 1));
+                shift = 0; result = 0;
+                do {
+                    b = encoded.charCodeAt(index++) - 63;
+                    result |= (b & 0x1f) << shift;
+                    shift += 5;
+                } while (b >= 0x20);
+                lng += ((result & 1) ? ~(result >> 1) : (result >> 1));
+                points.push([lat / 1e5, lng / 1e5]);
+            }
+            return points;
+        }
+
+        function renderTracks() {
+            var grid = document.getElementById('tracksGrid');
+            if (grid.children.length > 0) return; // already rendered
+
+            if (trackRecords.length === 0) {
+                grid.innerHTML = '<p class="tracks-empty">暂无轨迹数据。同步活动数据后，户外跑步的轨迹将展示在这里。</p>';
+                return;
+            }
+
+            trackRecords.forEach(function(track) {
+                var points = decodePolyline(track.summary_polyline);
+                if (points.length < 2) return;
+
+                // Normalize to SVG viewBox
+                var minLat = Infinity, maxLat = -Infinity, minLng = Infinity, maxLng = -Infinity;
+                points.forEach(function(p) {
+                    if (p[0] < minLat) minLat = p[0];
+                    if (p[0] > maxLat) maxLat = p[0];
+                    if (p[1] < minLng) minLng = p[1];
+                    if (p[1] > maxLng) maxLng = p[1];
+                });
+                var rangeLat = maxLat - minLat || 0.001;
+                var rangeLng = maxLng - minLng || 0.001;
+                var pad = 5;
+                var w = 200, h = 200;
+
+                var coords = points.map(function(p) {
+                    var x = pad + ((p[1] - minLng) / rangeLng) * (w - pad * 2);
+                    var y = pad + ((maxLat - p[0]) / rangeLat) * (h - pad * 2);
+                    return x.toFixed(1) + ',' + y.toFixed(1);
+                }).join(' ');
+
+                var card = document.createElement('div');
+                card.className = 'track-card';
+                card.innerHTML =
+                    '<svg viewBox="0 0 ' + w + ' ' + h + '" class="track-svg" preserveAspectRatio="xMidYMid meet">' +
+                        '<polyline points="' + coords + '" fill="none" stroke="#5c768d" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>' +
+                    '</svg>' +
+                    '<div class="track-info">' +
+                        '<span class="track-date">' + track.date + '</span>' +
+                        '<span class="track-stat">' + track.distance_km.toFixed(1) + ' km · ' + track.pace + '</span>' +
+                    '</div>';
+                grid.appendChild(card);
+            });
+        }
 
         var weightData = Array(timeline.length).fill(null);
         var fatData = Array(timeline.length).fill(null);

--- a/theme/style.css
+++ b/theme/style.css
@@ -336,6 +336,12 @@ pre code {
   margin: 4rem 0 2rem;
 }
 
+.running-header-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
 .running-header h1 {
   font-size: 1.5rem;
   font-weight: 300;
@@ -349,6 +355,83 @@ pre code {
   font-family: "Inter", sans-serif;
   font-size: 0.82rem;
   margin: 0;
+}
+
+.chart-tabs {
+  display: flex;
+  gap: 4px;
+}
+
+.chart-tab {
+  background: none;
+  border: 1px solid var(--border-color);
+  color: var(--text-muted);
+  font-family: "Inter", sans-serif;
+  font-size: 0.72rem;
+  padding: 3px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.chart-tab:hover {
+  color: var(--text-main);
+  border-color: var(--text-muted);
+}
+
+.chart-tab.active {
+  background: var(--text-main);
+  color: #fff;
+  border-color: var(--text-main);
+  opacity: 0.7;
+}
+
+.tracks-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+}
+
+.track-card {
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  overflow: hidden;
+  background: var(--bg-color);
+}
+
+.track-svg {
+  display: block;
+  width: 100%;
+  height: 140px;
+  background: var(--bg-color);
+}
+
+.track-info {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5rem 0.75rem;
+  font-family: "Inter", sans-serif;
+  font-size: 0.75rem;
+  border-top: 1px solid var(--border-color);
+}
+
+.track-date {
+  color: var(--text-muted);
+}
+
+.track-stat {
+  color: var(--text-main);
+  font-weight: 500;
+}
+
+.tracks-empty {
+  grid-column: 1 / -1;
+  text-align: center;
+  color: var(--text-muted);
+  font-family: "Inter", sans-serif;
+  font-size: 0.85rem;
+  padding: 3rem 0;
 }
 
 .dashboard-card {
@@ -480,6 +563,17 @@ pre code {
   .activity-table th {
     font-size: 0.6rem;
     letter-spacing: 1px;
+  }
+
+  .tracks-grid {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 0.75rem;
+  }
+
+  .running-header-row {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
   }
 }
 


### PR DESCRIPTION
## 改动

实现 [SAV-182](mention://issue/bfe30287-a363-4d24-b1b5-e10af991b629) — Running 页面添加轨迹 Tab。

### 修改文件

| 文件 | 改动 |
|------|------|
| `scripts/sync_garmin.py` | 提取 Garmin API 返回的 `summaryPolyline` 字段 |
| `build.js` | 构建 `tracksJSON`（最近 12 条有轨迹的活动） |
| `theme/running.ejs` | 图表/轨迹 Tab 切换 + polyline 解码 + SVG 缩略图渲染 |
| `theme/style.css` | Tab、轨迹卡片网格样式 + 移动端响应式 |

### 技术要点

- **零新依赖**：polyline 解码函数内联，纯 SVG 渲染
- 跑步机活动自动过滤（无 polyline 数据）
- 移动端网格降为 2 列
- 无轨迹数据时显示空状态提示

### 后续步骤

合并后需重新运行 `sync_garmin.py --secret ...` 全量同步一次，获取历史活动的 polyline 数据。新的户外跑步活动会自动包含轨迹。